### PR TITLE
Added RLN8-410-E to the UART table

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,9 @@ Model | Hardware | UART
 RLN8-410 | H3MB18 | ?
 RLN8-410 | N2MB02 | ?
 RLN8-410 | N3MB01 | ?
+RLN8-410-E | H3MB16 | yes
 RLN16-410 | H3MB18 | yes
+
 
 ### Firmware
 


### PR DESCRIPTION
Hello, I'm trying to explore this project and adapt it to my NVR which is an RLN8-410-E (hardware model is H3MB16), I do have access to the UART console, that's why I added it to the UART table on the README.md
